### PR TITLE
Serverlog

### DIFF
--- a/AR_Docent_MVC/Config/ServerConfig.cs
+++ b/AR_Docent_MVC/Config/ServerConfig.cs
@@ -10,6 +10,8 @@ namespace AR_Docent_MVC.Config
         public static readonly string connectionStringSql = "ConnectionStrings--Sql";
         //blob storage config
         public static readonly string connectionStringBlob = "ConnectionString--Blob";
+        //blob storage account
+        public static readonly string accountName = "imageaudiostorageaccount";
         //blob storage audio
         public static readonly string imgContainerName = "arimage";
         //blob storage audio config

--- a/AR_Docent_MVC/Controllers/UnityController.cs
+++ b/AR_Docent_MVC/Controllers/UnityController.cs
@@ -48,8 +48,8 @@ namespace AR_Docent_MVC.Controllers
                         name = products[i].name,
                         audio_name = products[i].audio_name,
                         image_name = products[i].img_name,
-                        image_url = _storageService.GetItemDownloadUrl(ServerConfig.imgContainerName, products[i].img_name),
-                        audio_url = _storageService.GetItemDownloadUrl(ServerConfig.audioContainerName, products[i].audio_name),
+                        //image_url = _storageService.GetItemDownloadUrl(ServerConfig.imgContainerName, products[i].img_name),
+                        //audio_url = _storageService.GetItemDownloadUrl(ServerConfig.audioContainerName, products[i].audio_name),
                         content = products[i].content,
                     };
                     info.Add(item);

--- a/AR_Docent_MVC/Service/ARBlobStorageService.cs
+++ b/AR_Docent_MVC/Service/ARBlobStorageService.cs
@@ -197,7 +197,6 @@ namespace AR_Docent_MVC.Service
                 DateTime now, end;
 
                 Debug.WriteLine("create sas token");
-                var conList = _blobServiceClient.GetBlobContainers().AsPages(default, 10);
                 Monitor.Enter(_sasToken);
                 foreach (string containerName in ServerConfig.containers)
                 {
@@ -216,7 +215,7 @@ namespace AR_Docent_MVC.Service
                         );
                     //use Default Azure Credential
                     BlobServiceClient _blobClient = new BlobServiceClient(
-                        new BlobUriBuilder(new Uri($"https://{_blobServiceClient.AccountName}.blob.core.windows.net")).ToUri(),
+                        new BlobUriBuilder(new Uri($"https://{ServerConfig.accountName}.blob.core.windows.net")).ToUri(),
                         new DefaultAzureCredential());
                     //get user delegation key
                     UserDelegationKey _userDelegationKey = _blobClient.GetUserDelegationKey(now.AddMinutes(-1), end);

--- a/AR_Docent_MVC/Startup.cs
+++ b/AR_Docent_MVC/Startup.cs
@@ -59,6 +59,8 @@ namespace AR_Docent_MVC
 
             app.UseAuthorization();
 
+            app.UseHttpLogging();
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute(

--- a/AR_Docent_MVC/appsettings.Development.json
+++ b/AR_Docent_MVC/appsettings.Development.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information"
     }
   }
 }


### PR DESCRIPTION
The trace listener AzureBlobTraceListener is disabled. ---> System.InvalidOperationException: The SAS URL for the cloud storage account is not specified. Use the environment variable 'DIAGNOSTICS_AZUREBLOBCONTAINERSASURL' to define it.at Microsoft.WindowsAzure.WebSites.Diagnostics.AzureBlobTraceListener.RefreshConfig()
로그가 서버에서 발생